### PR TITLE
Added documentation comment related to HTTPStatusCode

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -313,6 +313,7 @@ public class RouterResponse {
     ///
     /// - Parameter status: the HTTP status code.
     /// - Returns: this RouterResponse.
+    /// - Note: *KituraNet* needed to be imported to to set HTTPStatusCode. Can be done in way `response.status(HTTPStatusCode.unauthorized)`
     public func send(status: HTTPStatusCode) -> RouterResponse {
         guard !state.invokedEnd else {
             Log.warning("RouterResponse send(status:) invoked after end() for \(self.request.urlURL)")


### PR DESCRIPTION
Added a documentation comment so that the confusion related to importing `KituraNet` can be removed.

## Description
<!--- Describe your changes in detail -->
I had added documentation comment in `RouterResponse.swift` related to function `status` which takes `HTTPStatusCode` as an input parameter but you need to import `KituraNet` to actually pass that parameter because it's described there.
Although `Kitura` depends on `KituraNet` but then also it doesn't work as expected it will give you an error if you will try to do `response.status(HTTPStatusCode.unauthorized)` without importing `KituraNet` and will also give an error if you import `Kitura`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change will remove confusion from the developer's mind related to import of `KituraNet` I mean this might not be the perfect or very robust solution but will definitely help till there is no robust solution.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As the changes are in the form of comments so they are not affecting the logic so the code coverage is same.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.